### PR TITLE
React Hook Form 、　Zod導入

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "next": "14.2.13",
     "prisma": "^5.19.1",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "react-hook-form": "^7.53.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.9.0",
     "@prisma/client": "^5.19.1",
     "next": "14.2.13",
     "prisma": "^5.19.1",
     "react": "^18",
     "react-dom": "^18",
-    "react-hook-form": "^7.53.0"
+    "react-hook-form": "^7.53.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/components/user/InputRadio.tsx
+++ b/src/components/user/InputRadio.tsx
@@ -1,16 +1,18 @@
+import { UseFormRegisterReturn } from "react-hook-form";
 import styles from "../../styles/components/user/InputRadio.module.css";
 
 type InputRadioProps = {
   label: string;
-  name: string;
   value: string;
+  register: UseFormRegisterReturn;
+  checked?: boolean;
 };
 
-const InputRadio = ({ label, name, value }: InputRadioProps) => {
+const InputRadio = ({ label, value, register, checked }: InputRadioProps) => {
   return (
     <div className={styles.inputRadioGroup}>
       <label htmlFor={value}>{label}</label>
-      <input type="radio" id={value} name={name} value={value} />
+      <input type="radio" id={value} value={value} {...register} checked={checked} />
     </div>
   );
 };

--- a/src/components/user/InputText.tsx
+++ b/src/components/user/InputText.tsx
@@ -1,3 +1,4 @@
+import { UseFormRegisterReturn } from "react-hook-form";
 import styles from "../../styles/components/user/InputText.module.css";
 
 type InputProps = {
@@ -5,14 +6,15 @@ type InputProps = {
   name: string;
   type: string;
   errorMessage?: string;
-  handleChange?: () => void;
+  register: UseFormRegisterReturn;
 };
 
-const InputText = ({ label, name, type, handleChange }: InputProps) => {
+const InputText = ({ label, name, type, register, errorMessage }: InputProps) => {
   return (
     <div className={styles.inputContent}>
       <label htmlFor={name}>{label}</label>
-      <input type={type} id={name} onChange={handleChange} />
+      <input type={type} id={name} {...register} />
+      {errorMessage && <p className={styles.errorMessage}>{errorMessage}</p>}
     </div>
   );
 };

--- a/src/components/utils/Button.tsx
+++ b/src/components/utils/Button.tsx
@@ -5,12 +5,13 @@ type ButtonProps = {
   label: string;
   variant: "" | "primary" | "secondary";
   handleClick?: () => void;
+  disabled?: boolean;
 };
 
-const Button = ({ type, label, handleClick, variant }: ButtonProps) => {
+const Button = ({ type, label, handleClick, variant, disabled }: ButtonProps) => {
   const className = `${styles.button} ${styles[variant]}`;
   return (
-    <button type={type} onClick={handleClick} className={className}>
+    <button type={type} onClick={handleClick} className={className} disabled={disabled}>
       {label}
     </button>
   );

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+// アカウント登録ページ バリデーション
+export const registerSchema = z
+  .object({
+    name: z
+      .string()
+      .min(2, "ユーザー名は２文字以上にしてください")
+      .max(20, "ユーザー名は２０文字以下にしてください"),
+    email: z.string().email("無効なメールアドレスの形式です"),
+    gender: z.enum(["男性", "女性", "その他"], { required_error: "性別は必須項目です" }),
+    age: z
+      .number({ required_error: "年齢は必須項目です" })
+      .min(0, "0歳以上を指定してください")
+      .max(130, "130歳以下を指定してください"),
+    password: z
+      .string()
+      .min(6, "パスワードは６文字以内にしてください")
+      .max(20, "パスワードは20文字以内にしてください"),
+    confirmedPassword: z
+      .string()
+      .min(6, "確認用パスワードは６文字以内にしてください")
+      .max(20, "確認用パスワードは20文字以内にしてください"),
+  })
+  .refine((data) => data.password === data.confirmedPassword, {
+    message: "パスワードが一致しません",
+    path: ["confirmedPassword"],
+  });
+
+// ログインページ バリデーション
+export const loginSchema = z.object({
+  email: z.string().email("無効なメールアドレスの形式です"),
+  password: z
+    .string()
+    .min(6, "パスワードは6文字以内にしてください")
+    .max(20, "パスワードは20文字以内にしてください"),
+});
+
+// ユーザー情報編集ページ バリデーション
+export const editSchema = z.object({
+  name: z
+    .string({ required_error: "ユーザー名は必須項目です" })
+    .min(2, "ユーザー名は2文字以上にしてください")
+    .max(20, "ユーザー名は20文字以下にしてください"),
+  gender: z.enum(["男性", "女性", "その他"], { required_error: "性別は必須項目です" }),
+  age: z
+    .number({ required_error: "年齢は必須項目です" })
+    .min(0, "０歳以上を指定してください")
+    .max(130, "130歳以上を指定してください"),
+});

--- a/src/pages/user/edit.tsx
+++ b/src/pages/user/edit.tsx
@@ -3,22 +3,62 @@ import InputText from "@/components/user/InputText";
 import Title from "@/components/user/Title";
 import styles from "../../styles/pages/user/edit.module.css";
 import Button from "@/components/utils/Button";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { editSchema } from "@/lib/validation";
+
+type EditProps = {
+  name: string;
+  gender: string;
+  age: string;
+};
 
 const Edit = () => {
+  // React Hook Formにてフォーム管理、zodにてバリでション管理
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<EditProps>({
+    resolver: zodResolver(editSchema),
+  });
+
+  // ユーザー情報編集処理
+  const onSubmit = (data: EditProps) => {
+    console.log("ユーザー編集情報が送信されました", data);
+  };
+
   return (
     <main className={styles.editContent}>
-      <form className={styles.editForm}>
+      <form className={styles.editForm} onSubmit={handleSubmit(onSubmit)}>
         <Title title="ユーザー情報編集" />
-        <InputText name="name" label="ユーザー名" type="text" />
+        <InputText
+          name="name"
+          label="ユーザー名"
+          type="text"
+          register={register("name")}
+          errorMessage={errors.name?.message}
+        />
         <div className={styles.inputRadioGroup}>
-          <label>性別</label>
-          <InputRadio name="gender" label="男性" value="male" />
-          <InputRadio name="gender" label="女性" value="female" />
-          <InputRadio name="gender" label="その他" value="other" />
+          <div className={styles.inputRadioContent}>
+            <label>性別</label>
+            <InputRadio label="男性" value="男性" register={register("gender")} checked={true} />
+            <InputRadio label="女性" value="女性" register={register("gender")} />
+            <InputRadio label="その他" value="その他" register={register("gender")} />
+          </div>
+          {errors.gender && <p className={styles.errorMessage}>{errors.gender.message}</p>}
         </div>
-        <InputText name="age" label="年齢" type="number" />
+        <InputText
+          name="age"
+          label="年齢"
+          type="number"
+          register={register("age", {
+            setValueAs: (value) => (value === "" ? undefined : parseInt(value, 10)),
+          })}
+          errorMessage={errors.age?.message}
+        />
         <div className={styles.buttonGroup}>
-          <Button type="button" label="送信" variant="primary" />
+          <Button type="submit" label="送信" variant="primary" />
           <Button type="button" label="キャンセル" variant="secondary" />
         </div>
       </form>

--- a/src/pages/user/login.tsx
+++ b/src/pages/user/login.tsx
@@ -2,16 +2,47 @@ import Title from "@/components/user/Title";
 import styles from "../../styles/pages/user/login.module.css";
 import InputText from "@/components/user/InputText";
 import Button from "@/components/utils/Button";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { loginSchema } from "@/lib/validation";
+
+type LoginProps = {
+  email: string;
+  password: string;
+};
 
 const Login = () => {
+  // React Hook Formにてフォーム管理、zodにてバリデーション管理
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginProps>({ resolver: zodResolver(loginSchema) });
+
+  // ログイン処理
+  const onSubmit = (data: LoginProps) => {
+    console.log("ログイン情報が送信されました", data);
+  };
   return (
     <main className={styles.loginContent}>
-      <form className={styles.loginForm}>
+      <form className={styles.loginForm} onSubmit={handleSubmit(onSubmit)}>
         <Title title="ログイン" />
-        <InputText name="email" label="メールアドレス" type="text" />
-        <InputText name="password" label="パスワード" type="password" />
+        <InputText
+          name="email"
+          label="メールアドレス"
+          type="text"
+          register={register("email")}
+          errorMessage={errors.email?.message}
+        />
+        <InputText
+          name="password"
+          label="パスワード"
+          type="password"
+          register={register("password")}
+          errorMessage={errors.password?.message}
+        />
         <div className={styles.buttonGroup}>
-          <Button type="button" label="ログイン" variant="primary" />
+          <Button type="submit" label="ログイン" variant="primary" disabled={isSubmitting} />
           <Button type="button" label="戻る" variant="secondary" />
         </div>
       </form>

--- a/src/pages/user/register.tsx
+++ b/src/pages/user/register.tsx
@@ -3,25 +3,86 @@ import InputText from "@/components/user/InputText";
 import Title from "@/components/user/Title";
 import styles from "../../styles/pages/user/register.module.css";
 import Button from "@/components/utils/Button";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { registerSchema } from "@/lib/validation";
+
+type RegisterProps = {
+  name: string;
+  email: string;
+  gender: string;
+  age: string;
+  password: string;
+  confirmedPassword: string;
+};
 
 const Register = () => {
+  // React Hook Formにてフォーム管理、zodにてバリデーション実装
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<RegisterProps>({
+    resolver: zodResolver(registerSchema),
+  });
+
+  // 新規登録処理
+  const onSubmit = (data: RegisterProps) => {
+    console.log("フォームが送信されました", data);
+  };
+
   return (
     <main className={styles.registerContent}>
-      <form className={styles.registerForm}>
+      <form className={styles.registerForm} onSubmit={handleSubmit(onSubmit)}>
         <Title title="アカウント登録" />
-        <InputText name="name" label="ユーザー名" type="text" />
-        <InputText name="email" label="メールアドレス" type="text" />
+        <InputText
+          name="name"
+          label="ユーザー名"
+          type="text"
+          register={register("name")}
+          errorMessage={errors.name?.message}
+        />
+        <InputText
+          name="email"
+          label="メールアドレス"
+          type="text"
+          register={register("email")}
+          errorMessage={errors.email?.message}
+        />
         <div className={styles.inputRadioGroup}>
-          <label>性別</label>
-          <InputRadio name="gender" label="男性" value="male" />
-          <InputRadio name="gender" label="女性" value="female" />
-          <InputRadio name="gender" label="その他" value="other" />
+          <div className={styles.inputRadioContent}>
+            <label>性別</label>
+            <InputRadio label="男性" value="男性" register={register("gender")} checked={true} />
+            <InputRadio label="女性" value="女性" register={register("gender")} />
+            <InputRadio label="その他" value="その他" register={register("gender")} />
+          </div>
+          {errors.gender && <p className={styles.errorMessage}>{errors.gender.message}</p>}
         </div>
-        <InputText name="age" label="年齢" type="number" />
-        <InputText name="password" label="パスワード" type="password" />
-        <InputText name="confirmedPassword" label="確認用パスワード" type="password" />
+        <InputText
+          name="age"
+          label="年齢"
+          type="number"
+          register={register("age", {
+            setValueAs: (value) => (value === "" ? undefined : parseInt(value, 10)),
+          })}
+          errorMessage={errors.age?.message}
+        />
+        <InputText
+          name="password"
+          label="パスワード"
+          type="password"
+          register={register("password")}
+          errorMessage={errors.password?.message}
+        />
+        <InputText
+          name="confirmedPassword"
+          label="確認用パスワード"
+          type="password"
+          register={register("confirmedPassword")}
+          errorMessage={errors.confirmedPassword?.message}
+        />
         <div className={styles.buttonGroup}>
-          <Button type="button" label="登録" variant="primary" />
+          <Button type="submit" label="登録" variant="primary" disabled={isSubmitting} />
           <Button type="button" label="戻る" variant="secondary" />
         </div>
       </form>

--- a/src/styles/components/user/InputText.module.css
+++ b/src/styles/components/user/InputText.module.css
@@ -10,3 +10,8 @@
   width: 100%;
   padding: 0.2rem;
 }
+
+.errorMessage {
+  color: red;
+  font-size: 0.8rem;
+}

--- a/src/styles/pages/user/edit.module.css
+++ b/src/styles/pages/user/edit.module.css
@@ -13,7 +13,7 @@
   color: #555;
 }
 
-.inputRadioGroup {
+.inputRadioContent {
   display: flex;
   justify-content: space-between;
   margin-bottom: 0.5rem;
@@ -22,4 +22,9 @@
 .buttonGroup {
   display: flex;
   justify-content: space-around;
+}
+
+.errorMessage {
+  color: red;
+  font-size: 0.8rem;
 }

--- a/src/styles/pages/user/register.module.css
+++ b/src/styles/pages/user/register.module.css
@@ -13,7 +13,7 @@
   color: #555;
 }
 
-.inputRadioGroup {
+.inputRadioContent {
   display: flex;
   justify-content: space-between;
   margin-bottom: 0.5rem;
@@ -22,4 +22,9 @@
 .buttonGroup {
   display: flex;
   justify-content: space-around;
+}
+
+.errorMessage {
+  color: red;
+  font-size: 0.8rem;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,6 +55,11 @@
   dependencies:
     levn "^0.4.1"
 
+"@hookform/resolvers@^3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-3.9.0.tgz#cf540ac21c6c0cd24a40cf53d8e6d64391fb753d"
+  integrity sha512-bU0Gr4EepJ/EQsH/IwEzYLsT/PEj5C0ynLQ4m+GSHS+xKH4TfSelhluTgOaoc4kA5s7eCsQbM4wvZLzELmWzUg==
+
 "@humanwhocodes/module-importer@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz#af5b2691a22b44be847b0ca81641c5fb6ad0172c"
@@ -2446,3 +2451,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^3.23.8:
+  version "3.23.8"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
+  integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1926,6 +1926,11 @@ react-dom@^18:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
+react-hook-form@^7.53.0:
+  version "7.53.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.53.0.tgz#3cf70951bf41fa95207b34486203ebefbd3a05ab"
+  integrity sha512-M1n3HhqCww6S2hxLxciEXy2oISPnAzxY7gvwVPrtlczTM/1dDadXgUxDpHMrMTblDOcm/AXtXxHwZ3jpg1mqKQ==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
# 変更点、修正点
## React Hook Form、Zod導入
- React Hook Formを(user/register, user/login, user/edit)にて使用。
- バリデーションにはZodを使用。
- バリデーション内容はlib/validation.tsに記述
- 送信ボタンにて情報を送信中はボタンを押せないように変更
- React Hook Form追加に伴い、フォームにて使用するコンポーネントのpropsを修正

## その他
- まだDBに情報を登録する処理は実装していません。コンソールにフォームの情報を表示して動作確認をしました。