### PR TITLE
映画詳細ページ　スタイルのみ作成

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,16 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "image.tmdb.org",
+        port: "",
+      },
+    ],
+  },
+  pageExtensions: ["ts", "tsx", "js", "jsx"],
 };
 
 export default nextConfig;

--- a/src/components/movie/MovieDetail.tsx
+++ b/src/components/movie/MovieDetail.tsx
@@ -1,0 +1,76 @@
+import Image from "next/image";
+import styles from "@/styles/components/movie/MovieDetail.module.css";
+
+type MovieDetailProps = {
+  movieDetail: {
+    image: string;
+    title: string;
+    release_date: string;
+    runtime: number;
+    genres: { id: number; name: string }[];
+    overview: string;
+    homepage: string;
+    firstTwoCast: any;
+  };
+};
+
+const MovieDetail = ({ movieDetail }: MovieDetailProps) => {
+  return (
+    <div className={styles.movieDetail}>
+      <div className={styles.movieDetailContent}>
+        <Image
+          src={`https://image.tmdb.org/t/p/w300_and_h450_bestv2/${movieDetail.image}`}
+          alt="映画ポスター"
+          width={300}
+          height={400}
+          priority
+          className={styles.movieDetailImg}
+        />
+        <div className={styles.movieDetailInfo}>
+          <h2>{movieDetail.title}</h2>
+          <p>
+            <span>上映日：</span>
+            {movieDetail.release_date} / <span>上映時間：</span>
+            {movieDetail.runtime}分
+          </p>
+          <p>
+            <span>ホームページ：</span>
+            <a href={movieDetail.homepage}>こちら</a>から
+          </p>
+          <div className={styles.movieDetailGenres}>
+            <span>ジャンル：</span>
+            <ul>
+              {movieDetail.genres.map((genre) => {
+                return <li key={genre.id}>{genre.name}</li>;
+              })}
+            </ul>
+          </div>
+          <p className={styles.movieDetailOverview}>
+            <span>あらすじ：</span>
+            {movieDetail.overview}
+          </p>
+          <div>
+            <span>キャスト：</span>
+            <div className={styles.movieDetailCastGroup}>
+              {movieDetail.firstTwoCast.map((cast: any) => {
+                return (
+                  <div key={cast.id} className={styles.movieDetailCast}>
+                    <Image
+                      src={`https://image.tmdb.org/t/p/w300_and_h450_bestv2/${cast.profile_path}`}
+                      alt="キャストの画像"
+                      width={100}
+                      height={150}
+                    />
+                    <p>{cast.name}</p>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MovieDetail;

--- a/src/components/movie/SearchForm.tsx
+++ b/src/components/movie/SearchForm.tsx
@@ -1,0 +1,15 @@
+import styles from "@/styles/pages/movie/[id]/index.module.css";
+import Button from "../utils/Button";
+
+const SearchForm = () => {
+  return (
+    <div className={styles.searchForm}>
+      <form className={styles.searchFormContent}>
+        <input type="text" placeholder="映画検索" />
+        <Button type="submit" label="検索" variant="third" />
+      </form>
+    </div>
+  );
+};
+
+export default SearchForm;

--- a/src/components/utils/Button.tsx
+++ b/src/components/utils/Button.tsx
@@ -3,7 +3,7 @@ import styles from "../../styles/components/utils/Button.module.css";
 type ButtonProps = {
   type: "submit" | "reset" | "button" | undefined;
   label: string;
-  variant: "" | "primary" | "secondary";
+  variant: "" | "primary" | "secondary" | "third";
   handleClick?: () => void;
   disabled?: boolean;
 };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,7 +10,7 @@ export default function App({ Component, pageProps }: AppProps) {
       <AuthProvider>
         <Header />
         <Component {...pageProps} />
-        <Footer />
+        {/* <Footer /> */}
       </AuthProvider>
     </>
   );

--- a/src/pages/movie/[id]/index.tsx
+++ b/src/pages/movie/[id]/index.tsx
@@ -1,0 +1,44 @@
+import MovieDetail from "@/components/movie/MovieDetail";
+import SearchForm from "@/components/movie/SearchForm";
+import { GetServerSideProps } from "next";
+
+export const getServerSideProps: GetServerSideProps = async ({ params }) => {
+  const movieResponse = await fetch(
+    `https://api.themoviedb.org/3/movie/${params?.id}?api_key=586eeda24edab92c73392fb73d4d14ce&language=ja-JP`
+  );
+  const movieDetail = await movieResponse.json();
+  const castResponse = await fetch(
+    `https://api.themoviedb.org/3/movie/${params?.id}/credits?api_key=586eeda24edab92c73392fb73d4d14ce&language=ja-JP`
+  );
+  const movieCast = await castResponse.json();
+  const firstTwoCast = movieCast.cast.slice(0, 2);
+
+  return {
+    props: {
+      movieDetail,
+      firstTwoCast,
+    },
+  };
+};
+
+const Index = ({ movieDetail, firstTwoCast }: any) => {
+  const movie = {
+    image: movieDetail.poster_path,
+    title: movieDetail.title,
+    release_date: movieDetail.release_date,
+    runtime: movieDetail.runtime,
+    genres: movieDetail.genres,
+    overview: movieDetail.overview,
+    homepage: movieDetail.homepage,
+    firstTwoCast,
+  };
+
+  return (
+    <main>
+      <SearchForm />
+      <MovieDetail movieDetail={movie} />
+    </main>
+  );
+};
+
+export default Index;

--- a/src/styles/components/movie/MovieDetail.module.css
+++ b/src/styles/components/movie/MovieDetail.module.css
@@ -1,0 +1,75 @@
+.movieDetail {
+  margin: 1rem;
+  box-shadow: 0px 0px 15px -5px #777777;
+  border-radius: 10px;
+  background-color: white;
+  color: #666;
+}
+
+.movieDetailContent {
+  display: flex;
+  flex-direction: column;
+}
+
+.movieDetailImg {
+  margin: 0.5rem auto;
+  border-radius: 5px;
+}
+
+.movieDetailInfo {
+  padding: 0.3rem 1rem;
+}
+
+.movieDetailInfo > * {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid #6666664f;
+}
+
+.movieDetailInfo span {
+  font-weight: bold;
+  white-space: nowrap;
+}
+
+.movieDetailInfo > p > a {
+  color: orange;
+}
+
+.movieDetailGenres {
+  display: flex;
+}
+
+.movieDetailGenres > ul {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: start;
+}
+
+.movieDetailGenres > ul > li {
+  margin: 0.1rem 0.5rem;
+  list-style: none;
+}
+
+.movieDetailOverview {
+  line-height: 1.6;
+}
+
+.movieDetailCastGroup {
+  display: flex;
+  justify-content: space-around;
+  margin: 0.3rem;
+}
+
+.movieDetailCast {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.movieDetailCast p {
+  font-size: 0.8rem;
+  font-weight: 600;
+  white-space: normal;
+}

--- a/src/styles/components/utils/Button.module.css
+++ b/src/styles/components/utils/Button.module.css
@@ -24,3 +24,12 @@
 .secondary:hover {
   background-color: #e9e9e9;
 }
+
+.third {
+  background-color: black;
+  color: white;
+}
+
+.third:hover {
+  background-color: rgb(35, 35, 35);
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -14,11 +14,11 @@ html,
 body {
   max-width: 100vw;
   overflow-x: hidden;
+  background-color: #f1f1f1;
 }
 
 body {
   color: var(--foreground);
-  background: var(--background);
   font-family: Arial, Helvetica, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/src/styles/pages/movie/[id]/index.module.css
+++ b/src/styles/pages/movie/[id]/index.module.css
@@ -1,0 +1,24 @@
+.searchForm {
+  background-color: #f1f1f1;
+  padding: 0.5rem 1rem;
+}
+
+.searchFormContent {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.searchFormContent > input {
+  border-radius: 10px;
+  border: 2px solid rgb(255, 198, 92);
+  width: 80%;
+  height: 2rem;
+  margin-right: 1rem;
+  padding: 0.3rem 0.6rem;
+  color: #666;
+}
+
+.searchFormContent > input:focus {
+  border: 2px solid green;
+}


### PR DESCRIPTION
# 修正、変更点
## 映画詳細ページ作成（スタイルのみ）
- movie/[id]に作成
- 映画情報のみ表示
- 映画情報はidの値を参考してSSGで取得
- TMDBの画像取得のため、next.config.mjsを編集
- 映画情報表示コンポーネント作成
- あいまい検索コンポーネント作成

## その他
- アプリケーション全体の背景色を変更
- ボタンコンポーネントのカラーバリエーションを追加

以上、ご確認よろしくお願いいたします。